### PR TITLE
Add back changes lost during duo->browserify migration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,9 +27,9 @@ var Drift = module.exports = integration('Drift')
  */
 
 Drift.prototype.initialize = function() {
-  var drift = window.driftt || [];
-  window.drift = drift;
-  window.driftt = drift;
+  var drift;
+
+  drift = window.drift = window.driftt = window.driftt || [];
   drift.methods = ['identify', 'track', 'reset', 'debug', 'show', 'ping', 'page', 'hide', 'off', 'on'];
   drift.factory = function(method) {
     return function() {
@@ -55,9 +55,7 @@ Drift.prototype.initialize = function() {
  */
 
 Drift.prototype.loaded = function() {
-  // FIXME: This test should be improved by Driftt folks. It works in Chrome but
-  // not in PhantomJS.
-  return window.driftt && window.driftt._oldDriftt;
+  return window.drift !== undefined;
 };
 
 /**
@@ -69,7 +67,6 @@ Drift.prototype.loaded = function() {
 
 Drift.prototype.identify = function(identify) {
   if (!identify.userId()) return this.debug('user id required');
-  if (!identify.email()) return this.debug('user id required');
   var traits = identify.traits();
   var id = identify.userId();
   delete traits.id;


### PR DESCRIPTION
During the duo->browserify migration (https://github.com/segment-integrations/analytics.js-integration-drift/commit/8be1242fec8bda654e65acf5d9a534869a06c913), we accidentally reverted some changes that were in https://github.com/Driftt/analytics.js-integration-drift

This change un-reverts back to that implementation, keeping the changes needed for browserify.
